### PR TITLE
Fix registration test

### DIFF
--- a/backend_ta/src/test/java/dsd/codebenders/tournament_app/integration/authentication/RegisterTest.java
+++ b/backend_ta/src/test/java/dsd/codebenders/tournament_app/integration/authentication/RegisterTest.java
@@ -39,8 +39,6 @@ class RegisterTest {
     @Order(1)
     void registerSuccessTest()  {
 
-        playerRepository.deleteAll();
-
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode user = mapper.createObjectNode();
 
@@ -105,6 +103,7 @@ class RegisterTest {
 
         assertEquals(expectedRegistrationFailure, registrationFailure.getBody());
 
+        System.out.println(playerRepository.findAll());
 
     }
 


### PR DESCRIPTION
Don't clear player table when running test because there is admin user already in db and sql restraints cause test to fail otherwise